### PR TITLE
Add dependency on quarkus-undertow due to java.util.MissingResourceEx…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,10 +164,13 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-undertow</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
       <version>8.0.1</version>
-      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>


### PR DESCRIPTION
…ception: Can't find bundle for base name javax.servlet.LocalStrings, locale en_US