### PR TITLE
Adapt to new BuildFinder 2.0.1

### DIFF
--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/CacheProvider.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/CacheProvider.java
@@ -31,13 +31,11 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationChildBuilder;
-import org.infinispan.jboss.marshalling.commons.GenericJBossMarshaller;
 import org.infinispan.manager.DefaultCacheManager;
 import org.jboss.pnc.build.finder.core.BuildConfig;
 import org.jboss.pnc.build.finder.core.ChecksumType;
 import org.jboss.pnc.build.finder.core.ConfigDefaults;
-import org.jboss.pnc.build.finder.core.LocalFile;
-import org.jboss.pnc.build.finder.koji.KojiBuild;
+import org.jboss.pnc.build.finder.protobuf.ProtobufSerializerImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,16 +92,12 @@ public class CacheProvider {
             throw new IOException("Cache location is not writable: " + locationPath);
         }
 
-        KojiBuild.KojiBuildExternalizer kojiBuildExternalizer = new KojiBuild.KojiBuildExternalizer();
-        LocalFile.LocalFileExternalizer localFileExternalizer = new LocalFile.LocalFileExternalizer();
         GlobalConfigurationChildBuilder globalConfig = new GlobalConfigurationBuilder();
 
         globalConfig.globalState()
                 .persistentLocation(location)
                 .serialization()
-                .marshaller(new GenericJBossMarshaller())
-                .addAdvancedExternalizer(kojiBuildExternalizer.getId(), kojiBuildExternalizer)
-                .addAdvancedExternalizer(localFileExternalizer.getId(), localFileExternalizer)
+                .addContextInitializer(new ProtobufSerializerImpl())
                 .allowList()
                 .addRegexp(".*")
                 .create();


### PR DESCRIPTION
Build Finder 2.0.1 has transitioned to use Protobuf as the serialization
engine instead of JBoss Marshalling. As such, `CacheProvider` is also
updated to use the Protobuf implementation