### PR TITLE
[NCL-5611] Add support for Remote Infinispan server

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ keys listed below. They can be defined by setting the configuration key in:
 |koji.hub.url|The Koji Hub URL to find builds|http://brewhub.localhost/brewhub|
 |koji.web.url|The Koji Web URL|http://brewweb.localhost/brew|
 |pnc.url|The PNC URL to find builds|http://pnc.localhost|
+|infinispan.mode|Define whether to use Infinispan in `EMBEDDED` (default) or `REMOTE`|`EMBEDDED`|
+
+### Remote Infinispan
+If the `infinispan.mode` is set to `REMOTE`, the following configuration keys need to be defined:
+
+|Configuration Key|Description|Example|
+|-----------------|-----------|-------|
+|quarkus.infinispan-client.server-list|Comma-delimited Infinispan server list (\<hostname>[:\<port>])|localhost:11222|
+|quarkus.infinispan-client.auth-username|Username for the Infinispan server|admin|
+|quarkus.infinispan-client.auth-password|Password for the Infinispan server|password|
+
+The following caches also need to be present in the Infinispan server:
+
+- builds
+- builds-pnc
+- checksums-md5
+- checksums-pnc-md5
+- checksums-pnc-sha1
+- checksums-pnc-sha256
+- checksums-sha1
+- checksums-sha256
+- files-md5
+- files-sha1
+- files-sha256
+- rpms-md5
+- rpms-sha1
+- rpms-sha256
 
 ## Creating Docker Images with Docker Compose
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,8 +182,20 @@
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-client-hotrod</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
       <artifactId>infinispan-commons-jdk11</artifactId>
       <version>${version.org.infinispan}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query-dsl</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-remote-query-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.pnc</groupId>

--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/Finder.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/Finder.java
@@ -36,7 +36,7 @@ import javax.inject.Provider;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.eclipse.microprofile.context.ManagedExecutor;
-import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.commons.api.BasicCacheContainer;
 import org.jboss.pnc.build.finder.core.BuildConfig;
 import org.jboss.pnc.build.finder.core.BuildFinder;
 import org.jboss.pnc.build.finder.core.BuildFinderListener;
@@ -59,7 +59,7 @@ import com.redhat.red.build.koji.KojiClientException;
 public class Finder {
     private static final Logger LOGGER = LoggerFactory.getLogger(Finder.class);
 
-    private DefaultCacheManager cacheManager;
+    private BasicCacheContainer cacheManager;
 
     private Map<String, CancelWrapper> runningOperations = new ConcurrentHashMap<>();
 
@@ -70,7 +70,7 @@ public class Finder {
     BuildConfig config;
 
     @Inject
-    Provider<DefaultCacheManager> cacheProvider;
+    Provider<BasicCacheContainer> cacheProvider;
 
     @Inject
     ManagedExecutor pool;
@@ -85,7 +85,7 @@ public class Finder {
     public void init() {
         if (Boolean.FALSE.equals(config.getDisableCache())) {
             cacheManager = cacheProvider.get();
-            LOGGER.info("Initialized cache {}", cacheManager.getName());
+            LOGGER.info("Initialized cache {}", cacheManager);
         } else {
             LOGGER.info("Cache disabled");
         }
@@ -209,7 +209,7 @@ public class Finder {
                 "Starting distribution analysis for {} with config {} and cache manager {}",
                 files,
                 config,
-                cacheManager != null ? cacheManager.getName() : "disabled");
+                cacheManager != null ? cacheManager : "disabled");
 
         DistributionAnalyzer analyzer = new DistributionAnalyzer(files, config, cacheManager);
         analyzer.setListener(distributionAnalyzerListener);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,12 @@ quarkus.resteasy.path=/api
 quarkus.swagger-ui.always-include=true
 
 heartbeatPeriod=10s
+
+# Infinispan Configuration: can be EMBEDDED or REMOTE.
+infinispan.mode = EMBEDDED
+
+# If REMOTE infinispan mode is used, use the configs below to talk to the remote Infinispan server
+# Define multiple server list comma-delimited
+quarkus.infinispan-client.server-list=localhost:11222
+quarkus.infinispan-client.auth-username=admin
+quarkus.infinispan-client.auth-password=password


### PR DESCRIPTION
This commit adds support for remote infinispan server, in addition to
the current embedded infinispan setup.

Configuration
=============

The switch between remote and embedded is controlled in Quarkus config
by setting the `infinispan-mode` key with either value:

- EMBEDDED (default)
- REMOTE

If `REMOTE` is set, the following Quarkus config keys also need to be
configured:

- quarkus.infinispan-client.server-list (comma-delimited)
- quarkus.infinispan-client.auth-username
- quarkus.infinispan-client.auth-password

They are used to configure to which Infinispan remote server(s) to talk
to. Those keys are also used by the infinispan-quarkus-client, which we
plan to use later if we deprecate the Embedded mode.

Remote
------
When using the remote infinispan-mode, these caches need to be present
in the remote Infinispan server:

- builds
- builds-pnc
- checksums-md5
- checksums-pnc-md5
- checksums-pnc-sha1
- checksums-pnc-sha256
- checksums-sha1
- checksums-sha256
- files-md5
- files-sha1
- files-sha256
- rpms-md5
- rpms-sha1
- rpms-sha256