### PR TITLE
[NCL-6695] Imports cleanup; use the AnalyzePayload operation id as the identifier of the analysis operation and the heartbeat scheduler

### DIFF
--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/Finder.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/Finder.java
@@ -37,7 +37,6 @@ import javax.inject.Provider;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.infinispan.commons.api.BasicCacheContainer;
-import org.infinispan.manager.DefaultCacheManager;
 import org.jboss.pnc.api.deliverablesanalyzer.dto.FinderResult;
 import org.jboss.pnc.build.finder.core.BuildConfig;
 import org.jboss.pnc.build.finder.core.BuildFinder;

--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/model/AnalyzeResponse.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/model/AnalyzeResponse.java
@@ -24,6 +24,8 @@ import org.jboss.pnc.api.dto.Request;
  */
 public class AnalyzeResponse implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Analysis ID
      */

--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/model/FinderResultCreator.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/model/FinderResultCreator.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.validation.ConstraintViolationException;
 import javax.ws.rs.BadRequestException;
 
 import org.jboss.pnc.api.deliverablesanalyzer.dto.Artifact;


### PR DESCRIPTION
Has to be merged after https://github.com/project-ncl/pnc-api/pull/56.
This changes will make the deliverables-analyzer use the operation id as the identifier of the analysis operation run.