### PR TITLE
[NCL-6342] Add MDC headers to callback for analyze

### DIFF
--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/rest/LoggingFilter.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/rest/LoggingFilter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.pnc.deliverablesanalyzer.rest;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.pnc.api.constants.MDCHeaderKeys;
+import org.jboss.pnc.api.constants.MDCKeys;
+import org.jboss.pnc.common.Strings;
+import org.jboss.pnc.common.concurrent.Sequence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+/**
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+@Provider
+public class LoggingFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingFilter.class);
+    private static final String REQUEST_EXECUTION_START = "request-execution-start";
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        MDC.clear();
+        Map<String, String> mdcContext = getContextMap();
+        headerToMap(mdcContext, MDCHeaderKeys.REQUEST_CONTEXT, requestContext, () -> Sequence.nextId().toString());
+        headerToMap(mdcContext, MDCHeaderKeys.PROCESS_CONTEXT, requestContext);
+        headerToMap(mdcContext, MDCHeaderKeys.TMP, requestContext);
+        headerToMap(mdcContext, MDCHeaderKeys.EXP, requestContext);
+        headerToMap(mdcContext, MDCHeaderKeys.USER_ID, requestContext);
+
+        MDC.setContextMap(mdcContext);
+
+        requestContext.setProperty(REQUEST_EXECUTION_START, System.currentTimeMillis());
+
+        UriInfo uriInfo = requestContext.getUriInfo();
+        Request request = requestContext.getRequest();
+        LOGGER.info("Requested {} {}.", request.getMethod(), uriInfo.getRequestUri());
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        Long startTime = (Long) requestContext.getProperty(REQUEST_EXECUTION_START);
+
+        String took;
+        if (startTime == null) {
+            took = "-1";
+        } else {
+            took = Long.toString(System.currentTimeMillis() - startTime);
+        }
+
+        try (MDC.MDCCloseable mdcTook = MDC.putCloseable(MDCKeys.REQUEST_TOOK, took);
+                MDC.MDCCloseable mdcStatus = MDC
+                        .putCloseable(MDCKeys.RESPONSE_STATUS, Integer.toString(responseContext.getStatus()))) {
+            LOGGER.debug("Completed {}, took: {}ms.", requestContext.getUriInfo().getPath(), took);
+        }
+    }
+
+    private void headerToMap(
+            Map<String, String> mdcContext,
+            MDCHeaderKeys headerKeys,
+            ContainerRequestContext requestContext) {
+        String value = requestContext.getHeaderString(headerKeys.getHeaderName());
+        mdcContext.put(headerKeys.getMdcKey(), value);
+    }
+
+    private void headerToMap(
+            Map<String, String> map,
+            MDCHeaderKeys headerKeys,
+            ContainerRequestContext requestContext,
+            Supplier<String> defaultValue) {
+        String value = requestContext.getHeaderString(headerKeys.getHeaderName());
+        if (Strings.isEmpty(value)) {
+            map.put(headerKeys.getMdcKey(), defaultValue.get());
+        } else {
+            map.put(headerKeys.getMdcKey(), value);
+        }
+    }
+
+    private static Map<String, String> getContextMap() {
+        Map<String, String> context = MDC.getCopyOfContextMap();
+        if (context == null) {
+            context = new HashMap<>();
+        }
+        return context;
+    }
+}

--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/utils/MdcUtils.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/utils/MdcUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.deliverablesanalyzer.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.pnc.api.constants.MDCHeaderKeys;
+import org.slf4j.MDC;
+
+/**
+ * @author <a href="mailto:matejonnet@gmail.com">Matej Lazar</a>
+ */
+public final class MdcUtils {
+
+    /**
+     * Utility classes shouldn't have a public default constructor
+     */
+    private MdcUtils() {
+    }
+
+    /**
+     * TODO: what to do with exceptions
+     *
+     * @param result
+     * @param mdcMap
+     * @param mdcHeaderKeys
+     */
+    public static void putMdcToResultMap(
+            Map<String, String> result,
+            Map<String, String> mdcMap,
+            MDCHeaderKeys mdcHeaderKeys) {
+        if (mdcMap == null) {
+            throw new RuntimeException("Missing MDC map.");
+        }
+        if (mdcMap.get(mdcHeaderKeys.getMdcKey()) != null) {
+            result.put(mdcHeaderKeys.getHeaderName(), mdcMap.get(mdcHeaderKeys.getMdcKey()));
+        } else {
+            throw new RuntimeException("Missing MDC value " + mdcHeaderKeys.getMdcKey());
+        }
+    }
+
+    public static Map<String, String> mdcToMapWithHeaderKeys() {
+        Map<String, String> result = new HashMap<>();
+        Map<String, String> mdcMap = MDC.getCopyOfContextMap();
+        putMdcToResultMap(result, mdcMap, MDCHeaderKeys.PROCESS_CONTEXT);
+        putMdcToResultMap(result, mdcMap, MDCHeaderKeys.TMP);
+        putMdcToResultMap(result, mdcMap, MDCHeaderKeys.EXP);
+        putMdcToResultMap(result, mdcMap, MDCHeaderKeys.USER_ID);
+        return result;
+    }
+}

--- a/src/test/java/org/jboss/pnc/deliverablesanalyzer/rest/AnalyzeResourceTestWithMockedBrew.java
+++ b/src/test/java/org/jboss/pnc/deliverablesanalyzer/rest/AnalyzeResourceTestWithMockedBrew.java
@@ -82,7 +82,8 @@ public class AnalyzeResourceTestWithMockedBrew extends AnalyzeResourceTestAbstra
         brewHub.start();
 
         // when
-        Response response = given().body(new AnalyzePayload("1234", List.of(stubThreeArtsZip(1)), null, callbackRequest, null))
+        Response response = given()
+                .body(new AnalyzePayload("1234", List.of(stubThreeArtsZip(1)), null, callbackRequest, null))
                 .contentType(APPLICATION_JSON)
                 .when()
                 .post(analyzeUrl)

--- a/src/test/java/org/jboss/pnc/deliverablesanalyzer/rest/AnalyzerResourceTestWithDummyBrew.java
+++ b/src/test/java/org/jboss/pnc/deliverablesanalyzer/rest/AnalyzerResourceTestWithDummyBrew.java
@@ -130,8 +130,8 @@ public class AnalyzerResourceTestWithDummyBrew extends AnalyzeResourceTestAbstra
 
         // when
         // Start analysis
-        Response response = given()
-                .body(new AnalyzePayload("1234", List.of(stubThreeArtsZip(15000)), null, callbackRequest, heartbeatRequest))
+        Response response = given().body(
+                new AnalyzePayload("1234", List.of(stubThreeArtsZip(15000)), null, callbackRequest, heartbeatRequest))
                 .contentType(APPLICATION_JSON)
                 .when()
                 .post(analyzeUrl)
@@ -154,7 +154,8 @@ public class AnalyzerResourceTestWithDummyBrew extends AnalyzeResourceTestAbstra
         wiremock.stubFor(post(urlEqualTo(callbackRelativePath)).willReturn(aResponse().withStatus(HTTP_OK)));
 
         // when
-        analyzeResource.analyze(new AnalyzePayload("1234", List.of("xxyy:/malformedUrl.zip"), null, callbackRequest, null));
+        analyzeResource
+                .analyze(new AnalyzePayload("1234", List.of("xxyy:/malformedUrl.zip"), null, callbackRequest, null));
 
         // then
         verifyCallback(


### PR DESCRIPTION
This commit copies the `LoggingFilter` and `MdcUtils` from
repository-driver to intercept the MDC values set in the http header
requests, and stores it in SLF4J's MDC context (which is internally
attached to the executing thread)

From this, we append the MDC HTTP headers to the callback request
headers if the MDC header keys are not already specified.