### PR TITLE
[NCL-6344] Remove commented out cleanup code

### DIFF
--- a/src/main/java/org/jboss/pnc/deliverablesanalyzer/Finder.java
+++ b/src/main/java/org/jboss/pnc/deliverablesanalyzer/Finder.java
@@ -240,19 +240,6 @@ public class Finder {
         result = findBuilds(id, url, analyzer, futureChecksum, buildFinderListener, allTasks);
 
         LOGGER.info("Done finding builds for {}", url);
-
-        // TODO fix cleanup. It must:
-        // - support cancel
-        // - not affect running operations
-        // - run async
-        // Consider using dir/id{8}-urlHash{8}
-        /*
-         * boolean isClean = cleaner.cleanup(this.config.getOutputDirectory());
-         *
-         * if (isClean) { LOGGER.info("Cleanup after finding URL: {}", url); } else {
-         * LOGGER.warn("Cleanup failed after finding URL: {}", url); }
-         */
-
         return result;
     }
 


### PR DESCRIPTION
It was assumed that either the build-finder or the distribution-analyzer
code would create contents in the filesystem after each run. However,
they both only write contents to the filesystem if explicitly asked (via
`outputToFile` method), and do not write anything to the filesystem by
default.

The download of the zip to analyze is done via commons-vfs, which is an
abstraction of a filesystem and is cleaned up as needed by the garbage
collector.

Therefore, this commit removes the commented out cleanup code since they
are really not needed.