### PR TITLE
Enable http compression and decompression

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,10 @@ quarkus.application.name=pnc-deliverables-analyzer
 quarkus.http.idle-timeout=1H
 quarkus.http.cors=true
 quarkus.http.cors.origins=/.*/
+
+quarkus.http.enable-compression=true
+quarkus.http.enable-decompression=true
+
 quarkus.index-dependency.build-finder-core.group-id=org.jboss.pnc.build.finder
 quarkus.index-dependency.build-finder-core.artifact-id=core
 quarkus.index-dependency.build-finder-core.classifier=


### PR DESCRIPTION
This allows a client to upload compressed data to Deliverables-analyzer (decompression), and allows Deliverables-analyzer to reply with compressed data (compression setting)