### PR TITLE
Skip signing tag with gpg key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -763,6 +763,7 @@ limitations under the License.]]></inlineHeader>
           <tagNameFormat>@{project.version}</tagNameFormat>
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <releaseProfiles>empty-javadoc-jar,gpg-sign</releaseProfiles>
+          <signTag>false</signTag>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
We add the option to skip signing tags with gpg key during the maven-release-plugin execution. The plugin doesn't know how to pass the gpg passphrase also for the signing and fails.

This is triggered when jboss-parent is updated to version 50