### PR TITLE
Bump Quarkus to 3.34.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <version.com.mycila>5.0.0</version.com.mycila>
     <version.com.puppycrawl.tools>13.4.0</version.com.puppycrawl.tools>
     <version.git-commit-id-plugin>4.9.10</version.git-commit-id-plugin>
-    <version.io.quarkus>3.31.4</version.io.quarkus>
+    <version.io.quarkus>3.34.1</version.io.quarkus>
     <version.net.revelc.code.formatter.formatter-maven-plugin>2.26.0</version.net.revelc.code.formatter.formatter-maven-plugin>
     <version.net.revelc.code.impsort-maven-plugin>1.12.0</version.net.revelc.code.impsort-maven-plugin>
     <version.net.sourceforge.pmd>7.23.0</version.net.sourceforge.pmd>
@@ -99,6 +99,8 @@
     <version.org.codehaus.mojo.buildnumber-maven-plugin>3.3.0</version.org.codehaus.mojo.buildnumber-maven-plugin>
     <version.org.codehaus.mojo.versions-maven-plugin>2.21.0</version.org.codehaus.mojo.versions-maven-plugin>
     <version.org.ec4j.maven.editorconfig-maven-plugin>0.1.0</version.org.ec4j.maven.editorconfig-maven-plugin>
+    <version.org.infinispan>16.1.3</version.org.infinispan>
+    <version.org.infinispan.protostream>6.0.1</version.org.infinispan.protostream>
     <version.org.jboss.pnc.build.finder>2.6.8-SNAPSHOT</version.org.jboss.pnc.build.finder>
     <version.org.jboss.pnc.logging>3.0.4-SNAPSHOT</version.org.jboss.pnc.logging>
     <version.org.jboss.pnc.pnc>3.4.4</version.org.jboss.pnc.pnc>
@@ -121,6 +123,13 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${version.io.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-bom</artifactId>
+        <version>${version.org.infinispan}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -211,10 +220,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-infinispan-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>
     </dependency>
     <dependency>
@@ -267,6 +272,10 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-client-hotrod</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.pnc</groupId>
       <artifactId>dto</artifactId>
       <classifier>patch-builders-jakarta</classifier>
@@ -299,7 +308,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -714,13 +723,14 @@ limitations under the License.]]></inlineHeader>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-            <annotationProcessorPaths>
-                <path>
-                    <groupId>org.infinispan.protostream</groupId>
-                    <artifactId>protostream-processor</artifactId>
-                </path>
-            </annotationProcessorPaths>
-      </configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.infinispan.protostream</groupId>
+              <artifactId>protostream-processor</artifactId>
+              <version>${version.org.infinispan.protostream}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -877,18 +887,19 @@ limitations under the License.]]></inlineHeader>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId><executions>
-            <execution>
-              <id>attach-javadocs</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-              <configuration>
-                <failOnWarnings>false</failOnWarnings>
-                <failOnError>false</failOnError>
-              </configuration>
-            </execution>
-          </executions>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <failOnWarnings>false</failOnWarnings>
+                  <failOnError>false</failOnError>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Replace quarkus-infinispan-client with infinispan-client-hotrod since `CacheProvider` manages on its own and the Quarkus extension's bean eagerly connects causing tests to fail when no Infinispan server is running.

Rename quarkus-junit5 to quarkus-junit.

Add Infinispan BOM after the Quarkus BOM in dependency management to try to align Infinispan versions with Build Finder.